### PR TITLE
calendar-bot - Fix service / pod port name mismatch

### DIFF
--- a/charts/calendar-bot/Chart.yaml
+++ b/charts/calendar-bot/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/calendar-bot/templates/service.yaml
+++ b/charts/calendar-bot/templates/service.yaml
@@ -8,8 +8,8 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: main
+      targetPort: http
       protocol: TCP
-      name: main
+      name: http
   selector:
     {{- include "calendar-bot.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Ingress can't find the service since the selector can't find endpoints, so let's fix this oversight

Signed-off-by: Rhea Danzey <rdanzey@element.io>