### PR TITLE
element-call - Allow the config key to template directly into config so that parameters don't need to be enumerated in chart

### DIFF
--- a/charts/element-call/Chart.yaml
+++ b/charts/element-call/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: "0.1.8"
+version: "0.2.0"
 
 # This version number should be incremented each time you make changes
 # to the application.

--- a/charts/element-call/templates/config-template.yaml
+++ b/charts/element-call/templates/config-template.yaml
@@ -4,22 +4,4 @@ metadata:
   name: {{ .Release.Name }}-configmap
 data:
   config.json: |
-    {
-      "default_server_config": {
-        "m.homeserver": {
-          "base_url": "{{ .Values.config.homeserver.base_url }}",
-          "server_name": "{{ .Values.config.homeserver.server_name }}"
-        }
-      },
-      "livekit": {
-        "livekit_service_url": "{{ .Values.config.livekit.livekit_service_url }}"
-      },
-      "posthog": {
-        "api_key": "{{ .Values.config.posthog.api_key }}",
-        "api_host": "{{ .Values.config.posthog.api_host }}"
-      },
-      "rageshake": {
-        "submit_url": "{{ .Values.config.rageshake.submit_url }}"
-      },
-      "eula": "{{ .Values.config.eula_url }}"
-    }
+    {{ toPrettyJson .Values.config | nindent 4 }}

--- a/charts/element-call/values.yaml
+++ b/charts/element-call/values.yaml
@@ -82,9 +82,10 @@ tolerations: []
 affinity: {}
 
 config:
-  homeserver:
-    base_url: http://localhost:8008
-    server_name: localhost
+  default_server_config:
+    m.homeserver:
+      base_url: http://localhost:8008
+      server_name: localhost
   livekit:
     livekit_service_url: https://localhost/
   posthog:
@@ -92,4 +93,5 @@ config:
     api_host: https://localhost
   rageshake:
     submit_url:
-  eula_url:
+  eula:
+    url: ""


### PR DESCRIPTION
We've run into issues with trying to set parameters that are new to element-call and not yet configured in this chart. To reduce the dependency on going back and forth, we can just populate the configuration directly from the Helm values instead, which will allow new options to be set without having to change the chart itself.

Signed-off-by: Rhea Danzey <rdanzey@element.io>