### PR TITLE
remove livekit (and subkeys) from template since its now part of the …

### DIFF
--- a/charts/element-call/Chart.yaml
+++ b/charts/element-call/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: "0.2.1"
+version: "0.2.2"
 
 # This version number should be incremented each time you make changes
 # to the application.

--- a/charts/element-call/values.yaml
+++ b/charts/element-call/values.yaml
@@ -86,8 +86,6 @@ config:
     m.homeserver:
       base_url: http://localhost:8008
       server_name: localhost
-  livekit:
-    livekit_service_url: https://localhost/
   posthog:
     api_key:
     api_host: https://localhost


### PR DESCRIPTION
…homeserver's .well-known/matrix/client config